### PR TITLE
v18.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ and on top of that:
    
    - Installed from package management.
    - Using OpenJDK Java runtime.
-   - Web applications in /var/lib/tomcat9/webapps.
+   - Web applications in /var/lib/tomcat10/webapps.
    - Includes TurnKey web control panel.
    - Created Tomcat admin/manager roles and admin user.
    - Bind Tomcat HTTP connector to port 80 (default: 8080).

--- a/changelog
+++ b/changelog
@@ -1,3 +1,13 @@
+turnkey-tomcat-18.0 (1) turnkey; urgency=low
+
+  * Updated all relevant Debian packages to Bookworm/12 versions; including
+    Tomcat 10 and Java 17 (OpenJDK).
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Anton Pyrogovskyi <anton@turnkeylinux.org>  Mon, 29 Apr 2024 16:04:58 +0200
+
 turnkey-tomcat-17.1 (1) turnkey; urgency=low
 
   * Updated all Debian packages to latest.

--- a/conf.d/main
+++ b/conf.d/main
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 # configure tkl-webcp
-WEBROOT=/var/lib/tomcat9/webapps/ROOT
+WEBROOT=/var/lib/tomcat10/webapps/ROOT
 
 rm $WEBROOT/index.html
 

--- a/plan/main
+++ b/plan/main
@@ -3,10 +3,10 @@
 
 ant
 
-openjdk-11-jdk-headless
-openjdk-11-jre-headless
-
 authbind        /* Allows non-root programs to bind() to low ports */
+
+openjdk-17-jdk-headless
+openjdk-17-jre-headless
 
 default-mysql-server
 libmariadb-java


### PR DESCRIPTION
- plan: bump openjdk version to 17
- update webroot path
- update changelog
